### PR TITLE
Add resolution to latest Reason unpublished version 3.6.0

### DIFF
--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,3 +1,3 @@
 
 # Set eol to LF so files aren't converted to CRLF-eol on Windows.
-* text eol=lf
+* text eol=lf linguist-generated

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "08e6aea6796cfc0ffa5472231ec257ba",
+  "checksum": "523efb91234114374a2e898bb5feb586",
   "root": "bs-react-intl-extractor@link-dev:./package.json",
   "node": {
     "refmterr@3.3.0@d41d8cd9": {
@@ -14,11 +14,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.6.1000@d41d8cd9", "@reason-native/pastel@0.2.3@d41d8cd9",
+        "ocaml@4.6.1000@d41d8cd9", "@reason-native/pastel@0.3.0@d41d8cd9",
         "@reason-native/console@0.1.0@d41d8cd9",
         "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/atdgen@opam:2.0.0@46af0360",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -52,24 +52,25 @@
         "@opam/ppx_fast_pipe@opam:0.0.1@27d7b07b",
         "@opam/dune@opam:1.11.4@a7ccb7ae",
         "@opam/alcotest@opam:0.8.5@68e6c66c",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9"
       ],
       "devDependencies": [ "@esy-ocaml/merlin@3.0.5005@d41d8cd9" ]
     },
-    "@reason-native/pastel@0.2.3@d41d8cd9": {
-      "id": "@reason-native/pastel@0.2.3@d41d8cd9",
+    "@reason-native/pastel@0.3.0@d41d8cd9": {
+      "id": "@reason-native/pastel@0.3.0@d41d8cd9",
       "name": "@reason-native/pastel",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@reason-native/pastel/-/pastel-0.2.3.tgz#sha1:5c5d420c09874584ce15a38695c5dfd0f0ff5dfa"
+          "archive:https://registry.npmjs.org/@reason-native/pastel/-/pastel-0.3.0.tgz#sha1:07da3c5a0933e61bc3b353bc85aa71ac7c0f311c"
         ]
       },
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.1000@d41d8cd9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -86,9 +87,42 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
-        "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9"
       ],
       "devDependencies": []
+    },
+    "@opam/zed@opam:2.0.5@80585091": {
+      "id": "@opam/zed@opam:2.0.5@80585091",
+      "name": "@opam/zed",
+      "version": "opam:2.0.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/56/56414179d7cccba0e20005d958b5d39e#md5:56414179d7cccba0e20005d958b5d39e",
+          "archive:https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz#md5:56414179d7cccba0e20005d958b5d39e"
+        ],
+        "opam": {
+          "name": "zed",
+          "version": "2.0.5",
+          "path": "esy.lock/opam/zed.2.0.5"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@opam/base-bytes@opam:base@19d0c2ff"
+      ]
     },
     "@opam/yojson@opam:1.7.0@7056d985": {
       "id": "@opam/yojson@opam:1.7.0@7056d985",
@@ -143,6 +177,47 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.1000@d41d8cd9" ]
+    },
+    "@opam/utop@opam:2.4.3@5dd230c9": {
+      "id": "@opam/utop@opam:2.4.3@5dd230c9",
+      "name": "@opam/utop",
+      "version": "opam:2.4.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/4e/4e30ba6e224bea5776bc1a6ac3fee7f7548a35acf41d35e59c45913e28a0ea80#sha256:4e30ba6e224bea5776bc1a6ac3fee7f7548a35acf41d35e59c45913e28a0ea80",
+          "archive:https://github.com/ocaml-community/utop/releases/download/2.4.3/utop-2.4.3.tbz#sha256:4e30ba6e224bea5776bc1a6ac3fee7f7548a35acf41d35e59c45913e28a0ea80"
+        ],
+        "opam": {
+          "name": "utop",
+          "version": "2.4.3",
+          "path": "esy.lock/opam/utop.2.4.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/lwt_react@opam:1.1.3@72987fcf",
+        "@opam/lwt@opam:5.1.1@6f0a0b20",
+        "@opam/lambda-term@opam:2.0.3@9465cf1c",
+        "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/lwt_react@opam:1.1.3@72987fcf",
+        "@opam/lwt@opam:5.1.1@6f0a0b20",
+        "@opam/lambda-term@opam:2.0.3@9465cf1c",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-threads@opam:base@36803084"
+      ]
     },
     "@opam/topkg@opam:1.0.1@a42c631e": {
       "id": "@opam/topkg@opam:1.0.1@a42c631e",
@@ -278,6 +353,31 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/react@opam:1.2.1@0e11855f": {
+      "id": "@opam/react@opam:1.2.1@0e11855f",
+      "name": "@opam/react",
+      "version": "opam:1.2.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/ce/ce1454438ce4e9d2931248d3abba1fcc#md5:ce1454438ce4e9d2931248d3abba1fcc",
+          "archive:http://erratique.ch/software/react/releases/react-1.2.1.tbz#md5:ce1454438ce4e9d2931248d3abba1fcc"
+        ],
+        "opam": {
+          "name": "react",
+          "version": "1.2.1",
+          "path": "esy.lock/opam/react.1.2.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/topkg@opam:1.0.1@a42c631e",
+        "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "ocaml@4.6.1000@d41d8cd9" ]
+    },
     "@opam/re@opam:1.9.0@d4d5e13d": {
       "id": "@opam/re@opam:1.9.0@d4d5e13d",
       "name": "@opam/re",
@@ -355,6 +455,41 @@
       ],
       "devDependencies": [
         "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
+    "@opam/ocplib-endian@opam:1.0@aa720242": {
+      "id": "@opam/ocplib-endian@opam:1.0@aa720242",
+      "name": "@opam/ocplib-endian",
+      "version": "opam:1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/74/74b45ba33e189283170a748c2a3ed477#md5:74b45ba33e189283170a748c2a3ed477",
+          "archive:https://github.com/OCamlPro/ocplib-endian/archive/1.0.tar.gz#md5:74b45ba33e189283170a748c2a3ed477"
+        ],
+        "opam": {
+          "name": "ocplib-endian",
+          "version": "1.0",
+          "path": "esy.lock/opam/ocplib-endian.1.0"
+        }
+      },
+      "overrides": [
+        {
+          "opamoverride":
+            "esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override"
+        }
+      ],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/ocamlbuild@opam:0.14.0@6ac75d03",
+        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/base-bytes@opam:base@19d0c2ff",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
+        "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/base-bytes@opam:base@19d0c2ff"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -441,6 +576,31 @@
         "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
     },
+    "@opam/mmap@opam:1.1.0@b85334ff": {
+      "id": "@opam/mmap@opam:1.1.0@b85334ff",
+      "name": "@opam/mmap",
+      "version": "opam:1.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/8c/8c5d5fbc537296dc525867535fb878ba#md5:8c5d5fbc537296dc525867535fb878ba",
+          "archive:https://github.com/mirage/mmap/releases/download/v1.1.0/mmap-v1.1.0.tbz#md5:8c5d5fbc537296dc525867535fb878ba"
+        ],
+        "opam": {
+          "name": "mmap",
+          "version": "1.1.0",
+          "path": "esy.lock/opam/mmap.1.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
     "@opam/merlin-extend@opam:0.5@a5dd7d4b": {
       "id": "@opam/merlin-extend@opam:0.5@a5dd7d4b",
       "name": "@opam/merlin-extend",
@@ -489,6 +649,130 @@
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.1000@d41d8cd9" ]
+    },
+    "@opam/lwt_react@opam:1.1.3@72987fcf": {
+      "id": "@opam/lwt_react@opam:1.1.3@72987fcf",
+      "name": "@opam/lwt_react",
+      "version": "opam:1.1.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/1a/1a72b5ae4245707c12656632a25fc18c#md5:1a72b5ae4245707c12656632a25fc18c",
+          "archive:https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz#md5:1a72b5ae4245707c12656632a25fc18c"
+        ],
+        "opam": {
+          "name": "lwt_react",
+          "version": "1.1.3",
+          "path": "esy.lock/opam/lwt_react.1.1.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/lwt@opam:5.1.1@6f0a0b20", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/lwt@opam:5.1.1@6f0a0b20", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
+    "@opam/lwt_log@opam:1.1.1@2d7a797f": {
+      "id": "@opam/lwt_log@opam:1.1.1@2d7a797f",
+      "name": "@opam/lwt_log",
+      "version": "opam:1.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/02/02e93be62288037870ae5b1ce099fe59#md5:02e93be62288037870ae5b1ce099fe59",
+          "archive:https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz#md5:02e93be62288037870ae5b1ce099fe59"
+        ],
+        "opam": {
+          "name": "lwt_log",
+          "version": "1.1.1",
+          "path": "esy.lock/opam/lwt_log.1.1.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/lwt@opam:5.1.1@6f0a0b20", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "@opam/lwt@opam:5.1.1@6f0a0b20", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
+    "@opam/lwt@opam:5.1.1@6f0a0b20": {
+      "id": "@opam/lwt@opam:5.1.1@6f0a0b20",
+      "name": "@opam/lwt",
+      "version": "opam:5.1.1",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/4d/4ddec0f42b7aa4a310175a14c47c60a3#md5:4ddec0f42b7aa4a310175a14c47c60a3",
+          "archive:https://github.com/ocsigen/lwt/archive/5.1.1.tar.gz#md5:4ddec0f42b7aa4a310175a14c47c60a3"
+        ],
+        "opam": {
+          "name": "lwt",
+          "version": "5.1.1",
+          "path": "esy.lock/opam/lwt.5.1.1"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/seq@opam:0.2.2@e9144e45",
+        "@opam/result@opam:1.4@dc720aef",
+        "@opam/ocplib-endian@opam:1.0@aa720242",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.4@a7ccb7ae", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/base-unix@opam:base@87d0b2eb",
+        "@opam/base-threads@opam:base@36803084",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/seq@opam:0.2.2@e9144e45",
+        "@opam/result@opam:1.4@dc720aef",
+        "@opam/ocplib-endian@opam:1.0@aa720242",
+        "@opam/mmap@opam:1.1.0@b85334ff",
+        "@opam/dune-configurator@opam:1.0.0@4873acd8",
+        "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
+    "@opam/lambda-term@opam:2.0.3@9465cf1c": {
+      "id": "@opam/lambda-term@opam:2.0.3@9465cf1c",
+      "name": "@opam/lambda-term",
+      "version": "opam:2.0.3",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/90/903b6cc234598d67c7c905dfb5230209#md5:903b6cc234598d67c7c905dfb5230209",
+          "archive:https://github.com/ocaml-community/lambda-term/releases/download/2.0.3/lambda-term-2.0.3.tbz#md5:903b6cc234598d67c7c905dfb5230209"
+        ],
+        "opam": {
+          "name": "lambda-term",
+          "version": "2.0.3",
+          "path": "esy.lock/opam/lambda-term.2.0.3"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
+        "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/lwt_react@opam:1.1.3@72987fcf",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:5.1.1@6f0a0b20",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/zed@opam:2.0.5@80585091",
+        "@opam/react@opam:1.2.1@0e11855f",
+        "@opam/lwt_react@opam:1.1.3@72987fcf",
+        "@opam/lwt_log@opam:1.1.1@2d7a797f", "@opam/lwt@opam:5.1.1@6f0a0b20",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/camomile@opam:1.0.2@51b42ad8"
+      ]
     },
     "@opam/jbuilder@opam:transition@20522f05": {
       "id": "@opam/jbuilder@opam:transition@20522f05",
@@ -544,6 +828,31 @@
         "@opam/seq@opam:0.2.2@e9144e45"
       ]
     },
+    "@opam/fix@opam:20200131@0ecd2f01": {
+      "id": "@opam/fix@opam:20200131@0ecd2f01",
+      "name": "@opam/fix",
+      "version": "opam:20200131",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/99/991ff031666c662eaab638d2e0f4ac1d#md5:991ff031666c662eaab638d2e0f4ac1d",
+          "archive:https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz#md5:991ff031666c662eaab638d2e0f4ac1d"
+        ],
+        "opam": {
+          "name": "fix",
+          "version": "20200131",
+          "path": "esy.lock/opam/fix.20200131"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
+    },
     "@opam/easy-format@opam:1.3.2@0484b3c4": {
       "id": "@opam/easy-format@opam:1.3.2@0484b3c4",
       "name": "@opam/easy-format",
@@ -568,6 +877,25 @@
       "devDependencies": [
         "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ]
+    },
+    "@opam/dune-configurator@opam:1.0.0@4873acd8": {
+      "id": "@opam/dune-configurator@opam:1.0.0@4873acd8",
+      "name": "@opam/dune-configurator",
+      "version": "opam:1.0.0",
+      "source": {
+        "type": "install",
+        "source": [ "no-source:" ],
+        "opam": {
+          "name": "dune-configurator",
+          "version": "1.0.0",
+          "path": "esy.lock/opam/dune-configurator.1.0.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "@opam/dune@opam:1.11.4@a7ccb7ae", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [ "@opam/dune@opam:1.11.4@a7ccb7ae" ]
     },
     "@opam/dune@opam:1.11.4@a7ccb7ae": {
       "id": "@opam/dune@opam:1.11.4@a7ccb7ae",
@@ -661,6 +989,60 @@
         "ocaml@4.6.1000@d41d8cd9", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.6.1000@d41d8cd9" ]
+    },
+    "@opam/charInfo_width@opam:1.1.0@9d8d61b2": {
+      "id": "@opam/charInfo_width@opam:1.1.0@9d8d61b2",
+      "name": "@opam/charInfo_width",
+      "version": "opam:1.1.0",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/md5/c4/c4ab038e06f06a29692c05fdd7c268c5#md5:c4ab038e06f06a29692c05fdd7c268c5",
+          "archive:https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz#md5:c4ab038e06f06a29692c05fdd7c268c5"
+        ],
+        "opam": {
+          "name": "charInfo_width",
+          "version": "1.1.0",
+          "path": "esy.lock/opam/charInfo_width.1.1.0"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/camomile@opam:1.0.2@51b42ad8",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@opam/camomile@opam:1.0.2@51b42ad8"
+      ]
+    },
+    "@opam/camomile@opam:1.0.2@51b42ad8": {
+      "id": "@opam/camomile@opam:1.0.2@51b42ad8",
+      "name": "@opam/camomile",
+      "version": "opam:1.0.2",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://opam.ocaml.org/cache/sha256/f0/f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632#sha256:f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632",
+          "archive:https://github.com/yoriyuki/Camomile/releases/download/1.0.2/camomile-1.0.2.tbz#sha256:f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632"
+        ],
+        "opam": {
+          "name": "camomile",
+          "version": "1.0.2",
+          "path": "esy.lock/opam/camomile.1.0.2"
+        }
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae",
+        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+      ],
+      "devDependencies": [
+        "ocaml@4.6.1000@d41d8cd9", "@opam/dune@opam:1.11.4@a7ccb7ae"
+      ]
     },
     "@opam/biniou@opam:1.2.1@d7570399": {
       "id": "@opam/biniou@opam:1.2.1@d7570399",
@@ -908,26 +1290,29 @@
       "dependencies": [],
       "devDependencies": []
     },
-    "@esy-ocaml/reason@3.5.2@d41d8cd9": {
-      "id": "@esy-ocaml/reason@3.5.2@d41d8cd9",
+    "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9": {
+      "id":
+        "@esy-ocaml/reason@github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567@d41d8cd9",
       "name": "@esy-ocaml/reason",
-      "version": "3.5.2",
+      "version":
+        "github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://registry.npmjs.org/@esy-ocaml/reason/-/reason-3.5.2.tgz#sha1:ac48b63fd66fbbc1d77ab6a2b7e3a1ba21a8f40b"
+          "github:facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567"
         ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.6.1000@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
+        "ocaml@4.6.1000@d41d8cd9", "@opam/utop@opam:2.4.3@5dd230c9",
+        "@opam/result@opam:1.4@dc720aef",
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.5.0@3e319dbc",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
         "@opam/menhir@opam:20190924@004407ff",
-        "@opam/dune@opam:1.11.4@a7ccb7ae"
+        "@opam/fix@opam:20200131@0ecd2f01", "@opam/dune@opam:1.11.4@a7ccb7ae"
       ],
-      "devDependencies": []
+      "devDependencies": [ "ocaml@4.6.1000@d41d8cd9" ]
     },
     "@esy-ocaml/merlin@3.0.5005@d41d8cd9": {
       "id": "@esy-ocaml/merlin@3.0.5005@d41d8cd9",

--- a/esy.lock/opam/camomile.1.0.2/opam
+++ b/esy.lock/opam/camomile.1.0.2/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+synopsis: "A Unicode library"
+description: """
+Camomile is a Unicode library for OCaml. Camomile provides Unicode character
+type, UTF-8, UTF-16, UTF-32 strings, conversion to/from about 200 encodings,
+collation and locale-sensitive case mappings, and more. The library is currently
+designed for Unicode Standard 3.2."""
+maintainer: ["yoriyuki.y@gmail.com"]
+authors: ["Yoriyuki Yamagata"]
+license: "LGPL-2.1-or-later with OCaml-LGPL-linking-exception"
+homepage: "https://github.com/yoriyuki/Camomile"
+doc: "https://yoriyuki.github.io/Camomile/"
+bug-reports: "https://github.com/yoriyuki/Camomile/issues"
+depends: [
+  "dune" {>= "1.11"}
+  "ocaml" {>= "4.02.3"}
+]
+dev-repo: "git+https://github.com/yoriyuki/Camomile.git"
+build: [
+  ["ocaml" "configure.ml" "--share" "%{share}%/camomile"]
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs
+    "@install"
+    "@doc" {with-doc}
+  ]
+]
+url {
+  src:
+    "https://github.com/yoriyuki/Camomile/releases/download/1.0.2/camomile-1.0.2.tbz"
+  checksum: [
+    "sha256=f0a419b0affc36500f83b086ffaa36c545560cee5d57e84b729e8f851b3d1632"
+    "sha512=7586422e68779476206027c6ebbe19b677fbe459153221f7c952c7fae374c5c8232249cb76fdb1f482069707aa1580be827cd39693906142988268b7f0e7f6d0"
+  ]
+}

--- a/esy.lock/opam/charInfo_width.1.1.0/opam
+++ b/esy.lock/opam/charInfo_width.1.1.0/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+maintainer: "zandoye@gmail.com"
+authors: [ "ZAN DoYe" ]
+homepage: "https://bitbucket.org/zandoye/charinfo_width/"
+bug-reports: "https://bitbucket.org/zandoye/charinfo_width/issues"
+license: "MIT"
+dev-repo: "hg+https://bitbucket.org/zandoye/charinfo_width"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test & (ocaml:version >= "4.04.0")}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "result"
+  "camomile" {>= "1.0.0" & < "2.0~"}
+  "dune"
+  "ppx_expect" {with-test & < "v0.14"}
+]
+
+synopsis: "Determine column width for a character"
+description: """
+This module is implemented purely in OCaml and the width function follows the prototype of POSIX's wcwidth."""
+
+url {
+  src:"https://bitbucket.org/zandoye/charinfo_width/get/1.1.0.tar.gz"
+  checksum: "md5=c4ab038e06f06a29692c05fdd7c268c5"
+}

--- a/esy.lock/opam/dune-configurator.1.0.0/opam
+++ b/esy.lock/opam/dune-configurator.1.0.0/opam
@@ -1,0 +1,9 @@
+opam-version: "2.0"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml/dune"
+bug-reports: "https://github.com/ocaml/dune/issues"
+maintainer: "Jérémie Dimino"
+description: """
+dune.configurator library distributed with Dune 1.x
+"""
+depends: ["dune" {<"2.0.0"}]

--- a/esy.lock/opam/fix.20200131/opam
+++ b/esy.lock/opam/fix.20200131/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "francois.pottier@inria.fr"
+authors: [
+  "François Pottier <francois.pottier@inria.fr>"
+]
+homepage: "https://gitlab.inria.fr/fpottier/fix"
+dev-repo: "git+https://gitlab.inria.fr/fpottier/fix.git"
+bug-reports: "francois.pottier@inria.fr"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml" { >= "4.03" }
+  "dune" { >= "1.3" }
+]
+synopsis: "Facilities for memoization and fixed points"
+url {
+  src:
+    "https://gitlab.inria.fr/fpottier/fix/repository/20200131/archive.tar.gz"
+  checksum: [
+    "md5=991ff031666c662eaab638d2e0f4ac1d"
+    "sha512=01c45a1d90b02ec0939e968b185a6a373ac6117e2287b9a26d3db9d71e9569d086cea50da60710fcab5c2ed9d3b4c72b76839c0651e436f1fb39c77dc7c04b5e"
+  ]
+}

--- a/esy.lock/opam/lambda-term.2.0.3/opam
+++ b/esy.lock/opam/lambda-term.2.0.3/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/lambda-term"
+bug-reports: "https://github.com/ocaml-community/lambda-term/issues"
+dev-repo: "git://github.com/ocaml-community/lambda-term.git"
+license: "BSD-3-Clause"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "lwt"   {>= "4.0.0"}
+  "lwt_log"
+  "react"
+  "zed"   {>= "2.0.3" & < "3.0"}
+  "camomile" {>= "1.0.1"}
+  "lwt_react"
+  "dune" {>= "1.1.0"}
+]
+synopsis: "Terminal manipulation library for OCaml"
+description: """
+Lambda-term is a cross-platform library for manipulating the terminal. It
+provides an abstraction for keys, mouse events, colors, as well as a set of
+widgets to write curses-like applications. The main objective of lambda-term is
+to provide a higher level functional interface to terminal manipulation than,
+for example, ncurses, by providing a native OCaml interface instead of bindings
+to a C library. Lambda-term integrates with zed to provide text edition
+facilities in console applications."""
+url {
+  src: "https://github.com/ocaml-community/lambda-term/releases/download/2.0.3/lambda-term-2.0.3.tbz"
+  checksum: "md5=903b6cc234598d67c7c905dfb5230209"
+}

--- a/esy.lock/opam/lwt.5.1.1/opam
+++ b/esy.lock/opam/lwt.5.1.1/opam
@@ -1,0 +1,65 @@
+opam-version: "2.0"
+
+synopsis: "Promises and event-driven I/O"
+
+version: "5.1.1"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérôme Vouillon"
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "cppo" {build & >= "1.1.0"}
+  "dune" {>= "1.7.0"}
+  "dune-configurator"
+  "mmap" {>= "1.1.0"} # mmap is needed as long as Lwt supports OCaml < 4.06.0.
+  "ocaml" {>= "4.02.0"}
+  "ocplib-endian"
+  "result" # result is needed as long as Lwt supports OCaml 4.02.
+  "seq" # seq is needed as long as Lwt supports OCaml < 4.07.0.
+
+  "bisect_ppx" {dev & >= "1.3.0"}
+  "ocamlfind" {dev & >= "1.7.3-1"}
+]
+
+depopts: [
+  "base-threads"
+  "base-unix"
+  "conf-libev"
+]
+
+conflicts: [
+  "ocaml-variants" {= "4.02.1+BER"}
+]
+
+post-messages: [
+  "Lwt 5.0.0 has made some minor breaking changes. See
+  https://github.com/ocsigen/lwt/issues/584"
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: "A promise is a value that may become determined in the future.
+
+Lwt provides typed, composable promises. Promises that are resolved by I/O are
+resolved by Lwt in parallel.
+
+Meanwhile, OCaml code, including code creating and waiting on promises, runs in
+a single thread by default. This reduces the need for locks or other
+synchronization primitives. Code can be run in parallel on an opt-in basis."
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/5.1.1.tar.gz"
+  checksum: "md5=4ddec0f42b7aa4a310175a14c47c60a3"
+}

--- a/esy.lock/opam/lwt_log.1.1.1/opam
+++ b/esy.lock/opam/lwt_log.1.1.1/opam
@@ -1,0 +1,30 @@
+opam-version: "2.0"
+
+synopsis: "Lwt logging library (deprecated)"
+
+version: "1.1.1"
+license: "LGPL-2.0-or-later"
+homepage: "https://github.com/ocsigen/lwt_log"
+doc: "https://github.com/ocsigen/lwt_log/blob/master/src/core/lwt_log_core.mli"
+bug-reports: "https://github.com/ocsigen/lwt_log/issues"
+
+authors: [
+  "Shawn Wagner"
+  "Jérémie Dimino"
+]
+maintainer: "Anton Bachin <antonbachin@yahoo.com>"
+dev-repo: "git+https://github.com/ocsigen/lwt_log.git"
+
+depends: [
+  "dune" {>= "1.0"}
+  "lwt" {>= "4.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/aantron/lwt_log/archive/1.1.1.tar.gz"
+  checksum: "md5=02e93be62288037870ae5b1ce099fe59"
+}

--- a/esy.lock/opam/lwt_react.1.1.3/opam
+++ b/esy.lock/opam/lwt_react.1.1.3/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+
+synopsis: "Helpers for using React with Lwt"
+
+version: "1.1.3"
+license: "MIT"
+homepage: "https://github.com/ocsigen/lwt"
+doc: "https://ocsigen.org/lwt/api/Lwt_react"
+bug-reports: "https://github.com/ocsigen/lwt/issues"
+
+authors: [
+  "Jérémie Dimino"
+]
+maintainer: [
+  "Anton Bachin <antonbachin@yahoo.com>"
+]
+dev-repo: "git+https://github.com/ocsigen/lwt.git"
+
+depends: [
+  "dune"
+  "lwt" {>= "3.0.0"}
+  "ocaml"
+  "react" {>= "1.0.0"}
+]
+
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+
+url {
+  src: "https://github.com/ocsigen/lwt/archive/4.3.0.tar.gz"
+  checksum: "md5=1a72b5ae4245707c12656632a25fc18c"
+}

--- a/esy.lock/opam/mmap.1.1.0/opam
+++ b/esy.lock/opam/mmap.1.1.0/opam
@@ -1,0 +1,24 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: ["Jérémie Dimino <jeremie@dimino.org>" "Anton Bachin" ]
+homepage: "https://github.com/mirage/mmap"
+bug-reports: "https://github.com/mirage/mmap/issues"
+doc: "https://mirage.github.io/mmap/"
+dev-repo: "git+https://github.com/mirage/mmap.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"
+  "dune" {>= "1.6"}
+]
+synopsis: "File mapping functionality"
+description: """
+This project provides a Mmap.map_file functions for mapping files in memory.
+"""
+url {
+  src:
+    "https://github.com/mirage/mmap/releases/download/v1.1.0/mmap-v1.1.0.tbz"
+  checksum: "md5=8c5d5fbc537296dc525867535fb878ba"
+}

--- a/esy.lock/opam/ocplib-endian.1.0/opam
+++ b/esy.lock/opam/ocplib-endian.1.0/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+authors: "Pierre Chambart"
+maintainer: "pierre.chambart@ocamlpro.com"
+homepage: "https://github.com/OCamlPro/ocplib-endian"
+build: [
+  ["ocaml" "setup.ml" "-configure" "--disable-debug" "--prefix" prefix]
+  ["ocaml" "setup.ml" "-build"]
+]
+install: [
+  ["ocaml" "setup.ml" "-install"]
+]
+remove: ["ocamlfind" "remove" "ocplib-endian"]
+depends: [
+  "ocaml"
+  "base-bytes"
+  "ocamlfind"
+  "cppo" {>= "1.1.0"}
+  "ocamlbuild" {build}
+]
+dev-repo: "git+https://github.com/OCamlPro/ocplib-endian.git"
+bug-reports: "https://github.com/OCamlPro/ocplib-endian/issues"
+synopsis:
+  "Optimised functions to read and write int16/32/64 from strings and bigarrays, based on new primitives added in version 4.01."
+description: """
+The library implements three modules:
+* [EndianString](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianString.cppo.mli) works directly on strings, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBytes](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBytes.cppo.mli) works directly on bytes, and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;
+* [EndianBigstring](https://github.com/OCamlPro/ocplib-endian/blob/master/src/endianBigstring.cppo.mli) works on bigstrings (Bigarrays of chars), and provides submodules BigEndian and LittleEndian, with their unsafe counter-parts;"""
+flags: light-uninstall
+url {
+  src: "https://github.com/OCamlPro/ocplib-endian/archive/1.0.tar.gz"
+  checksum: "md5=74b45ba33e189283170a748c2a3ed477"
+}

--- a/esy.lock/opam/react.1.2.1/opam
+++ b/esy.lock/opam/react.1.2.1/opam
@@ -1,0 +1,33 @@
+opam-version: "2.0"
+maintainer: "Daniel Bünzli <daniel.buenzl i@erratique.ch>"
+homepage: "http://erratique.ch/software/react"
+authors: ["Daniel Bünzli <daniel.buenzl i@erratique.ch>"]
+doc: "http://erratique.ch/software/react/doc/React"
+dev-repo: "git+http://erratique.ch/repos/react.git"
+bug-reports: "https://github.com/dbuenzli/react/issues"
+tags: [ "reactive" "declarative" "signal" "event" "frp" "org:erratique" ]
+license: "ISC"
+depends: [
+  "ocaml" {>= "4.01.0"}
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "topkg" {build & >= "0.9.0"}
+]
+build:
+[[ "ocaml" "pkg/pkg.ml" "build"
+           "--dev-pkg" "%{pinned}%" ]]
+synopsis: "Declarative events and signals for OCaml"
+description: """
+Release %%VERSION%%
+
+React is an OCaml module for functional reactive programming (FRP). It
+provides support to program with time varying values : declarative
+events and signals. React doesn't define any primitive event or
+signal, it lets the client chooses the concrete timeline.
+
+React is made of a single, independent, module and distributed under
+the ISC license."""
+url {
+  src: "http://erratique.ch/software/react/releases/react-1.2.1.tbz"
+  checksum: "md5=ce1454438ce4e9d2931248d3abba1fcc"
+}

--- a/esy.lock/opam/utop.2.4.3/opam
+++ b/esy.lock/opam/utop.2.4.3/opam
@@ -1,0 +1,41 @@
+opam-version: "2.0"
+maintainer: "jeremie@dimino.org"
+authors: "Jérémie Dimino"
+license: "BSD3"
+homepage: "https://github.com/ocaml-community/utop"
+bug-reports: "https://github.com/ocaml-community/utop/issues"
+doc: "https://ocaml-community.github.io/utop/"
+depends: [
+  "ocaml" {>= "4.03.0" & < "4.11"}
+  "base-unix"
+  "base-threads"
+  "ocamlfind" {>= "1.7.2"}
+  "lambda-term" {>= "2.0" & < "3.0"}
+  "lwt"
+  "lwt_react"
+  "camomile"
+  "react" {>= "1.0.0"}
+  "cppo" {build & >= "1.1.2"}
+  "dune" {>= "1.0"}
+]
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+dev-repo: "git+https://github.com/ocaml-community/utop.git"
+synopsis: "Universal toplevel for OCaml"
+description: """
+utop is an improved toplevel (i.e., Read-Eval-Print Loop or REPL) for
+OCaml.  It can run in a terminal or in Emacs. It supports line
+edition, history, real-time and context sensitive completion, colors,
+and more.  It integrates with the Tuareg mode in Emacs.
+"""
+url {
+  src:
+    "https://github.com/ocaml-community/utop/releases/download/2.4.3/utop-2.4.3.tbz"
+  checksum: [
+    "sha256=4e30ba6e224bea5776bc1a6ac3fee7f7548a35acf41d35e59c45913e28a0ea80"
+    "sha512=507917f4256c4a37058a106598a61aa092301f008b7e9385950a615e37b7f1a217f1e3b116678cb90ef1938c038ed135dabf2f9987c8fec21b5eb322a005632a"
+  ]
+}

--- a/esy.lock/opam/zed.2.0.5/opam
+++ b/esy.lock/opam/zed.2.0.5/opam
@@ -1,0 +1,32 @@
+opam-version: "2.0"
+maintainer: "opam-devel@lists.ocaml.org"
+authors: ["Jérémie Dimino"]
+homepage: "https://github.com/ocaml-community/zed"
+bug-reports: "https://github.com/ocaml-community/zed/issues"
+dev-repo: "git://github.com/ocaml-community/zed.git"
+license: "BSD-3-Clause"
+depends: [
+  "ocaml" {>= "4.02.3"}
+  "dune" {>= "1.1.0"}
+  "base-bytes"
+  "camomile" {>= "1.0.1"}
+  "react"
+  "charInfo_width" {>= "1.1.0" & < "2.0~"}
+]
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+synopsis: "Abstract engine for text edition in OCaml"
+description: """
+Zed is an abstract engine for text edition. It can be used to write text
+editors, edition widgets, readlines, ... Zed uses Camomile to fully support the
+Unicode specification, and implements an UTF-8 encoded string type with
+validation, and a rope datastructure to achieve efficient operations on large
+Unicode buffers. Zed also features a regular expression search on ropes. To
+support efficient text edition capabilities, Zed provides macro recording and
+cursor management facilities."""
+url {
+  src: "https://github.com/ocaml-community/zed/releases/download/2.0.5/zed-2.0.5.tbz"
+  checksum: "md5=56414179d7cccba0e20005d958b5d39e"
+}

--- a/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/files/esy-fix.patch
+++ b/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/files/esy-fix.patch
@@ -1,0 +1,13 @@
+--- ./setup.ml
++++ ./setup.ml
+@@ -6331,9 +6331,7 @@
+           [
+             "-classic-display";
+             "-no-log";
+-            "-no-links";
+-            "-install-lib-dir";
+-            (Filename.concat (standard_library ()) "ocamlbuild")
++            "-no-links"
+           ]
+         else
+           [];

--- a/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/files/ocplib-endian-0.8.patch
+++ b/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/files/ocplib-endian-0.8.patch
@@ -1,0 +1,41 @@
+--- ./myocamlbuild.ml
++++ ./myocamlbuild.ml
+@@ -573,6 +573,24 @@
+    Add a dependency after dropping support for 4.01 and earlier. *)
+ let dispatch_cppo = function
+   | After_rules -> begin
++    let is_directory s =
++      let slen = String.length s in
++      let s =
++        if Sys.os_type <> "Win32" || slen < 2 then
++          s
++        else
++          match s.[slen-1] with
++          | '\\' | '/' ->
++              if slen <> 3 || s.[1] <> ':' then
++                String.sub s 0 (slen -1)
++              else
++                (match s.[0] with
++                | 'A' .. 'Z' | 'a' .. 'z' -> s
++                | _ -> String.sub s 0 (slen -1))
++          | _ -> s
++	    in
++      Pathname.is_directory s
++    in
+       let cppo_rules ext =
+         let dep   = "%(name).cppo"-.-ext
+         and prod1 = "%(name: <*> and not <*.cppo>)"-.-ext
+@@ -591,11 +609,11 @@
+       pflag ["cppo"] "cppo_D" (fun s -> S [A "-D"; A s]) ;
+       pflag ["cppo"] "cppo_U" (fun s -> S [A "-U"; A s]) ;
+       pflag ["cppo"] "cppo_I" (fun s ->
+-        if Pathname.is_directory s then S [A "-I"; P s]
++        if is_directory s then S [A "-I"; P s]
+         else S [A "-I"; P (Pathname.dirname s)]
+       ) ;
+       pdep ["cppo"] "cppo_I" (fun s ->
+-        if Pathname.is_directory s then [] else [s]) ;
++        if is_directory s then [] else [s]) ;
+       flag ["cppo"; "cppo_q"] (A "-q") ;
+       flag ["cppo"; "cppo_s"] (A "-s") ;
+       flag ["cppo"; "cppo_n"] (A "-n") ;

--- a/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/package.json
+++ b/esy.lock/overrides/opam__s__ocplib_endian_opam__c__1.0_opam_override/package.json
@@ -1,0 +1,34 @@
+{
+  "build": [
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < ocplib-endian-0.8.patch' : 'true'}"
+    ],
+    [
+      "bash",
+      "-c",
+      "#{os == 'windows' ? 'patch -p1 < esy-fix.patch' : 'true'}"
+    ],
+    [
+      "ocaml",
+      "setup.ml",
+      "-configure",
+      "--disable-debug",
+      "--prefix",
+      "#{self.install}"
+    ],
+    [
+      "ocaml",
+      "setup.ml",
+      "-build"
+    ]
+  ],
+  "install": [
+    [
+      "ocaml",
+      "setup.ml",
+      "-install"
+    ]
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "zip": "esy build && node scripts/createZip.js"
   },
   "dependencies": {
-    "@esy-ocaml/reason": "^3.5.2",
+    "@esy-ocaml/reason": "*",
     "@opam/alcotest": "^0.8.5",
-    "@opam/dune": "*",
+    "@opam/dune": "1.11.4",
     "@opam/ppx_fast_pipe": "^0.0.1",
     "@opam/yojson": "^1.7.0",
     "ocaml": "~4.6.1000",
@@ -33,5 +33,8 @@
   },
   "devDependencies": {
     "@esy-ocaml/merlin": "*"
+  },
+  "resolutions": {
+    "@esy-ocaml/reason": "facebook/reason#8f71db0b88c31842d866d46a18b71a1ce1709567"
   }
 }


### PR DESCRIPTION
Fixes #41 by adding a resolution to latest Reason commit.

Note that Dune has to be pinned to latest v1 version (1.11.4) as esy doesn't support Dune 2 yet.