### PR TITLE
Add description support for record type messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ module Msg = {
 };
 ```
 
+You also can pass descriptions to the records with:
+```reason
+let foo = [@intl.description "Hello description"] {id: "message.hello", defaultMessage: "Hello"};
+```
+
 ## Message Definition (bs-react-intl 1.x)
 
 Formatted messages may be defined in your source files in one of the following ways:

--- a/bin/Version.re
+++ b/bin/Version.re
@@ -1,1 +1,1 @@
-let version = "0.9.0";
+let version = "0.9.1";

--- a/lib/ExtractionIterator.re
+++ b/lib/ExtractionIterator.re
@@ -70,7 +70,7 @@ let extractMessagesFromValueBindings = (callback, valueBindings: list(value_bind
   valueBindings
   |> List.iter(valueBinding =>
        switch (valueBinding) {
-       // Match with [@intl.description "i am description"]
+       // Match with [@intl.description "i am description"] let foo = { ... };
        | {
            pvb_pat: {ppat_desc: Ppat_var(_)},
            pvb_expr: {

--- a/lib/Message.re
+++ b/lib/Message.re
@@ -6,10 +6,10 @@ type t = {
 
 let compare = (a, b) => compare(a.id, b.id);
 
-let fromStringMap = map => {
+let fromStringMap = (~description=?, map) => {
   let id = map |> StringMap.find_opt("id");
   let defaultMessage = map |> StringMap.find_opt("defaultMessage");
-  let description = map |> StringMap.find_opt("description");
+  let description = description |> Option.is_none ? map |> StringMap.find_opt("description") : description;
   switch (id, defaultMessage) {
   | (Some(id), Some(defaultMessage)) => Some({id, defaultMessage, description})
   | _ => None

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bs-react-intl-extractor",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Message extractor for bs-react-intl",
   "author": "Christoph Knittel <christoph.knittel@cca.io>",
   "license": "MIT",

--- a/test/__snapshots__/Extract.a27e9fd5.0.snapshot
+++ b/test/__snapshots__/Extract.a27e9fd5.0.snapshot
@@ -16,6 +16,11 @@ Extract › full
     \"description\": \"Description for message 1.7\"
   },
   { \"id\": \"test1.msg1.8\", \"defaultMessage\": \"This is message 1.8\" },
+  {
+    \"id\": \"test1.msg1.9\",
+    \"defaultMessage\": \"This is message 1.9\",
+    \"description\": \"Description for message 1.9\"
+  },
   { \"id\": \"test1.msg2.1\", \"defaultMessage\": \"This is message 2.1\" },
   {
     \"id\": \"test1.msg2.2\",

--- a/testData/test1/Test_1_1.re
+++ b/testData/test1/Test_1_1.re
@@ -58,3 +58,11 @@ module Msg2 = {
 
   let ignored2 = {id: "test1.ignored1.2", defaultMessage: "This message is ignored"};
 };
+
+module Msg3 = {
+  open ReactIntl;
+
+  [@intl.messages];
+
+  let msg19 = [@intl.description "Description for message 1.9"] {id: "test1.msg1.9", defaultMessage: "This is message 1.9"};
+};


### PR DESCRIPTION
We at @ahrefs use have use messages descriptions quite often, and lack of description support was the blocker to migrate from object message type to record.

In this PR I propose to pass message descriptions to records with `[@intl.description ...]` annotation, ex:
```reason
let msg = [@intl.description "Description for message"] {id: "i.am.id", defaultMessage: "i.am.defaultMessage"};
```

In this case, only the extractor aware of message description, and we don't have to deal with `{... description: None}`, `{... description: Some("description")}` in the records, [as we discussed before](https://github.com/reasonml-community/bs-react-intl/pull/31)
cc @cknitt 
